### PR TITLE
Remove redhat_access_insights.log from v2

### DIFF
--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -2190,11 +2190,6 @@
             "symbolic_name": "yum_repos_d"
         },
         {
-            "file": "/var/log/redhat-access-insights/redhat-access-insights.log",
-            "pattern": [],
-            "symbolic_name": "redhat_access_insights_log"
-        },
-        {
             "file": "/var/log/redhat_access_proactive/redhat_access_proactive.log",
             "pattern": [],
             "symbolic_name": "redhat_access_proactive_log"


### PR DESCRIPTION
We don't need to collect /var/log/redhat_access_insights.log for v2 client