### PR TITLE
Gather modularity related information

### DIFF
--- a/uploader.json
+++ b/uploader.json
@@ -1251,6 +1251,11 @@
             "symbolic_name": "dirsrv_errors"
         },
         {
+            "file": "/etc/dnf/modules.d/.*\\.module",
+            "pattern": [],
+            "symbolic_name": "dnf_modules"
+        },
+        {
             "file": "/etc/redhat-access-insights/machine-id",
             "pattern": [],
             "symbolic_name": "machine_id1"

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1251,6 +1251,11 @@
             "symbolic_name": "dirsrv_errors"
         },
         {
+            "file": "/etc/dnf/modules.d/.*\\.module",
+            "pattern": [],
+            "symbolic_name": "dnf_modules"
+        },
+        {
             "file": "/etc/redhat-access-insights/machine-id",
             "pattern": [],
             "symbolic_name": "machine_id1"


### PR DESCRIPTION
Newer versions of YUM (based on DNF) are storing
additional metadata related to modularity functionality
in the /etc/dnf/modules.d/ directory.
These files are needed in order to properly calculate
package updates.

Signed-off-by: Tomas Kasparek <tkasparek@redhat.com>