### PR TITLE
Specs for /var/log/ceilometer/collector.log

### DIFF
--- a/uploader.json
+++ b/uploader.json
@@ -1130,6 +1130,16 @@
             ],
             "symbolic_name": "ceilometer_compute_log"
         },
+	{
+            "file": "/var/log/ceilometer/collector.log",
+            "pattern": [],
+            "symbolic_name": "ceilometer_collector_log"
+        },
+        {
+            "file": "/var/log/containers/ceilometer/collector.log",
+            "pattern": [],
+            "symbolic_name": "ceilometer_collector_log"
+        },
         {
             "file": "/etc/ceph/ceph.conf",
             "pattern": [

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1130,6 +1130,16 @@
             ],
             "symbolic_name": "ceilometer_compute_log"
         },
+	{
+            "file": "/var/log/ceilometer/collector.log",
+            "pattern": [],
+            "symbolic_name": "ceilometer_collector_log"
+        },
+        {
+            "file": "/var/log/containers/ceilometer/collector.log",
+            "pattern": [],
+            "symbolic_name": "ceilometer_collector_log"
+        },
         {
             "file": "/etc/ceph/ceph.conf",
             "pattern": [


### PR DESCRIPTION
I noticed that the entry is missing in uploader.json but the parser is merged in the commit
https://github.com/RedHatInsights/insights-core/commit/a65e8254fd883f1329c8618fc4db5229cc0a9598

Signed-off-by: Sachin Patil <psachin@redhat.com>