### PR TITLE
Allow collection of files like /etc/krb5.conf.d/crypto-policies - without .conf in name.

### DIFF
--- a/uploader.json
+++ b/uploader.json
@@ -1752,11 +1752,6 @@
             "symbolic_name": "krb5"
         },
         {
-            "file": "/etc/krb5.conf.d/()*.*\\.conf",
-            "pattern": [],
-            "symbolic_name": "krb5_conf_d"
-        },
-        {
             "file": "/sys/kernel/mm/ksm/run",
             "pattern": [],
             "symbolic_name": "ksmstate"
@@ -3038,6 +3033,11 @@
         {
             "glob": "/var/opt/amq-broker/*/etc/broker.xml",
             "symbolic_name": "amq_broker",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/krb5.conf.d/*",
+            "symbolic_name": "krb5_conf_d",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1752,11 +1752,6 @@
             "symbolic_name": "krb5"
         },
         {
-            "file": "/etc/krb5.conf.d/()*.*\\.conf",
-            "pattern": [],
-            "symbolic_name": "krb5_conf_d"
-        },
-        {
             "file": "/sys/kernel/mm/ksm/run",
             "pattern": [],
             "symbolic_name": "ksmstate"
@@ -3033,6 +3028,11 @@
         {
             "glob": "/var/opt/amq-broker/*/etc/broker.xml",
             "symbolic_name": "amq_broker",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/krb5.conf.d/*",
+            "symbolic_name": "krb5_conf_d",
             "pattern": []
         },
         {


### PR DESCRIPTION
The file /etc/krb5.conf.d/crypto-policies exists in the default installation of RHEL8 and the rule `hardening_cryptopol_services` that we've made for a potential demo for Summit needs to know about the file's existence. And it can't, because it doesn't match the pattern.

@wcmitchell @SteveHNH @bfahr could you please check whether the change is correct and non-problematic, and if it is fine, could you please merge it next week or some time like that? (I'm not 100% sure I correctly comprehend the regexes that are involved.)

@kgrant @skontar @matysek FYI