### PR TITLE
Remove non-functional specs dependent upon the iface precommand

### DIFF
--- a/uploader.json
+++ b/uploader.json
@@ -81,12 +81,6 @@
             "symbolic_name": "date_utc"
         },
         {
-            "command": "/sbin/dcbtool gc  dcb",
-            "pattern": [],
-            "pre_command": "iface",
-            "symbolic_name": "dcbtool_gc_dcb"
-        },
-        {
             "command": "/bin/df -al",
             "pattern": [],
             "symbolic_name": "df__al"
@@ -1108,12 +1102,6 @@
             "command": "/bin/systool -b scsi -v",
             "pattern": [],
             "symbolic_name": "systool_b_scsi_v"
-        },
-        {
-            "command": "/usr/bin/teamdctl  state dump",
-            "pattern": [],
-            "pre_command": "iface",
-            "symbolic_name": "teamdctl_state_dump"
         },
         {
             "command": "/usr/bin/find /usr/share -maxdepth 1 -name 'tomcat*' -exec /bin/grep -R -s 'VirtualDirContext' --include '*.xml' '{}' +",

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -76,12 +76,6 @@
             "symbolic_name": "date_utc"
         },
         {
-            "command": "/sbin/dcbtool gc  dcb",
-            "pattern": [],
-            "pre_command": "iface",
-            "symbolic_name": "dcbtool_gc_dcb"
-        },
-        {
             "command": "/bin/df -al",
             "pattern": [],
             "symbolic_name": "df__al"
@@ -1108,12 +1102,6 @@
             "command": "/bin/systool -b scsi -v",
             "pattern": [],
             "symbolic_name": "systool_b_scsi_v"
-        },
-        {
-            "command": "/usr/bin/teamdctl  state dump",
-            "pattern": [],
-            "pre_command": "iface",
-            "symbolic_name": "teamdctl_state_dump"
         },
         {
             "command": "/usr/bin/find /usr/share -maxdepth 1 -name 'tomcat*' -exec /bin/grep -R -s 'VirtualDirContext' --include '*.xml' '{}' +",


### PR DESCRIPTION
* iface must be last arg to command for precommand to work
* dcbtools gc <iface> dcb
* teamctld <iface> state dump