### PR TITLE
 Convert regex specs to glob specs

### DIFF
--- a/uploader.json
+++ b/uploader.json
@@ -1244,38 +1244,6 @@
             "symbolic_name": "avc_cache_threshold"
         },
         {
-            "file": "/var/log/tomcat/()*catalina\\.out",
-            "pattern": [
-                "APPARENT DEADLOCK!",
-                "NoCobblerTokenException: We had an error trying to login."
-            ],
-            "symbolic_name": "catalina_out"
-        },
-        {
-            "file": "/var/log/tomcat6/()*catalina\\.out",
-            "pattern": [
-                "APPARENT DEADLOCK!",
-                "NoCobblerTokenException: We had an error trying to login."
-            ],
-            "symbolic_name": "catalina_out"
-        },
-        {
-            "file": "/tomcat-logs/tomcat/()*catalina\\.out",
-            "pattern": [
-                "APPARENT DEADLOCK!",
-                "NoCobblerTokenException: We had an error trying to login."
-            ],
-            "symbolic_name": "catalina_out"
-        },
-        {
-            "file": "/tomcat-logs/tomcat6/()*catalina\\.out",
-            "pattern": [
-                "APPARENT DEADLOCK!",
-                "NoCobblerTokenException: We had an error trying to login."
-            ],
-            "symbolic_name": "catalina_out"
-        },
-        {
             "file": "/proc/driver/cciss/()*cciss.*",
             "pattern": [],
             "symbolic_name": "cciss"
@@ -3176,6 +3144,16 @@
         {
             "glob": "/proc/net/bonding/bond*",
             "symbolic_name": "bond",
+            "pattern": []
+        },
+        {
+            "glob": "/var/log/tomcat*/catalina.out",
+            "symbolic_name": "catalina_out",
+            "pattern": []
+        },
+        {
+            "glob": "/tomcat-logs/tomcat*/catalina.out",
+            "symbolic_name": "catalina_out",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -1537,7 +1537,7 @@
             "symbolic_name": "ovirt_engine_ui_log"
         },
         {
-            "file": "/etc/systemd/()*journald\\.conf",
+            "file": "/etc/systemd/journald.conf",
             "pattern": [],
             "symbolic_name": "etc_journald_conf"
         },

--- a/uploader.json
+++ b/uploader.json
@@ -1969,14 +1969,6 @@
             "symbolic_name": "nfs_exports"
         },
         {
-            "file": "/etc/exports.d/()*.*\\.exports",
-            "pattern": [
-                "*",
-                "no_root_squash"
-            ],
-            "symbolic_name": "nfs_exports_d"
-        },
-        {
             "file": "/etc/nginx/()*.conf",
             "pattern": [],
             "symbolic_name": "nginx_conf"
@@ -3147,6 +3139,11 @@
         {
             "glob": "/sys/class/net/*/address",
             "symbolic_name": "mac_addresses",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/exports.d/*.exports",
+            "symbolic_name": "nfs_exports_d",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -2186,18 +2186,6 @@
             "symbolic_name": "puppetserver_config"
         },
         {
-            "file": "/var/lib/pgsql/data/pg_log/()*postgresql-.+\\.log",
-            "pattern": [
-                "FATAL",
-                "checkpoints are occurring too frequently",
-                "connection limit exceeded for non-superusers",
-                "database is not accepting commands to avoid wraparound data loss in database",
-                "must be vacuumed within",
-                "remaining connection slots are reserved for non-replication superuser connections"
-            ],
-            "symbolic_name": "postgresql_log"
-        },
-        {
             "file": "/proc/net/snmp",
             "pattern": [],
             "symbolic_name": "proc_snmp_ipv4"
@@ -3144,6 +3132,21 @@
         {
             "glob": "/etc/yum/pluginconf.d/*.conf",
             "symbolic_name": "pluginconf_d",
+            "pattern": []
+        },
+        {
+            "glob": "/var/lib/pgsql/data/pg_log/postgresql-*.log",
+            "symbolic_name": "postgresql_log",
+            "pattern": []
+        },
+        {
+            "glob": "/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_log/postgresql-*.log",
+            "symbolic_name": "postgresql_log",
+            "pattern": []
+        },
+        {
+            "glob": "/database/postgresql-*.log",
+            "symbolic_name": "postgresql_log",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -1726,7 +1726,7 @@
             "symbolic_name": "kexec_crash_size"
         },
         {
-            "file": "/etc/()*krb5\\.conf",
+            "file": "/etc/krb5.conf",
             "pattern": [],
             "symbolic_name": "krb5"
         },
@@ -3205,7 +3205,7 @@
         },
         {
             "glob": "/etc/krb5.conf.d/*",
-            "symbolic_name": "krb5_conf_d",
+            "symbolic_name": "krb5",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -2211,11 +2211,6 @@
             "symbolic_name": "qemu_conf"
         },
         {
-            "file": "/etc/libvirt/qemu/()*.+\\.xml",
-            "pattern": [],
-            "symbolic_name": "qemu_xml"
-        },
-        {
             "file": "/etc/rabbitmq/rabbitmq-env.conf",
             "pattern": [],
             "symbolic_name": "rabbitmq_env"
@@ -3147,6 +3142,11 @@
         {
             "glob": "/database/postgresql-*.log",
             "symbolic_name": "postgresql_log",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/libvirt/qemu/*.xml",
+            "symbolic_name": "qemu_xml",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -2174,11 +2174,6 @@
             "symbolic_name": "password_auth"
         },
         {
-            "file": "/etc/yum/pluginconf.d/()*\\w+\\.conf",
-            "pattern": [],
-            "symbolic_name": "pluginconf_d"
-        },
-        {
             "file": "/var/lib/pgsql/data/postgresql.conf",
             "pattern": [],
             "symbolic_name": "postgresql_conf"
@@ -3144,6 +3139,11 @@
         {
             "glob": "/etc/opt/rh/rh-nginx*/nginx/default.d/*",
             "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/yum/pluginconf.d/*.conf",
+            "symbolic_name": "pluginconf_d",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -1244,11 +1244,6 @@
             "symbolic_name": "avc_cache_threshold"
         },
         {
-            "file": "/proc/net/bonding/()*bond.*",
-            "pattern": [],
-            "symbolic_name": "bond"
-        },
-        {
             "file": "/var/log/tomcat/()*catalina\\.out",
             "pattern": [
                 "APPARENT DEADLOCK!",
@@ -3178,6 +3173,11 @@
         }
     ],
     "globs": [
+        {
+            "glob": "/proc/net/bonding/bond*",
+            "symbolic_name": "bond",
+            "pattern": []
+        },
         {
             "glob": "/sys/devices/system/cpu/cpu[0-9]*/online",
             "symbolic_name": "cpu_cores",

--- a/uploader.json
+++ b/uploader.json
@@ -1898,13 +1898,23 @@
             "symbolic_name": "modprobe"
         },
         {
-            "file": "/etc/()*mongod.conf",
+            "file": "/etc/mongod.conf",
             "pattern": [
                 "dbpath",
                 "destination",
                 "syslog",
                 "systemLog"
             ],
+            "symbolic_name": "mongod_conf"
+        },
+        {
+            "file": "/etc/mongodb.conf",
+            "pattern": [],
+            "symbolic_name": "mongod_conf"
+        },
+        {
+            "file": "/etc/opt/rh/rh-mongodb26/mongod.conf",
+            "pattern": [],
             "symbolic_name": "mongod_conf"
         },
         {
@@ -2311,15 +2321,6 @@
             "file": "/etc/resolv.conf",
             "pattern": [],
             "symbolic_name": "resolv_conf"
-        },
-        {
-            "file": "/etc/opt/rh/rh-mongodb26/()*mongod.conf",
-            "pattern": [
-                "destination",
-                "syslog",
-                "systemLog"
-            ],
-            "symbolic_name": "rh_mongodb26_conf"
         },
         {
             "file": "/etc/sysconfig/rhn/()*rhn-entitlement-cert\\.xml.*",

--- a/uploader.json
+++ b/uploader.json
@@ -1663,25 +1663,7 @@
             "symbolic_name": "jbcs_httpd24_httpd_error_log"
         },
         {
-            "file": "/etc/ImageMagick/()*policy\\.xml",
-            "pattern": [
-                "</policymap>",
-                "<policy",
-                "<policymap>"
-            ],
-            "symbolic_name": "imagemagick_policy"
-        },
-        {
-            "file": "/usr/lib64/ImageMagick-6.5.4/config/()*policy\\.xml",
-            "pattern": [
-                "</policymap>",
-                "<policy",
-                "<policymap>"
-            ],
-            "symbolic_name": "imagemagick_policy"
-        },
-        {
-            "file": "/usr/lib/ImageMagick-6.5.4/config/()*policy\\.xml",
+            "file": "/etc/ImageMagick/policy.xml",
             "pattern": [
                 "</policymap>",
                 "<policy",
@@ -3164,6 +3146,11 @@
         {
             "glob": "/etc/sysconfig/network-scripts/route-*",
             "symbolic_name": "ifcfg_static_route",
+            "pattern": []
+        },
+        {
+            "glob": "/usr/lib*/ImageMagick-6.5.4/config/policy.xml",
+            "symbolic_name": "imagemagick_policy",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -2660,23 +2660,7 @@
             "symbolic_name": "vdsm_logger_conf"
         },
         {
-            "file": "/etc/()*virt-who\\.conf",
-            "pattern": [
-                "[",
-                "configs",
-                "debug",
-                "env",
-                "interval",
-                "log_",
-                "oneshot",
-                "owner",
-                "server",
-                "type"
-            ],
-            "symbolic_name": "virt_who_conf"
-        },
-        {
-            "file": "/etc/virt-who.d/()*.*\\.conf",
+            "file": "/etc/virt-who.conf",
             "pattern": [
                 "[",
                 "configs",
@@ -3152,6 +3136,11 @@
         {
             "glob": "/usr/lib/systemd/journald.conf.d/*.conf",
             "symbolic_name": "usr_journald_conf_d",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/virt-who.d/*.conf",
+            "symbolic_name": "virt_who_conf",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -2743,11 +2743,6 @@
             "symbolic_name": "logrotate_conf"
         },
         {
-            "file": "/etc/logrotate.d/().*",
-            "pattern": [],
-            "symbolic_name": "logrotate_conf"
-        },
-        {
             "file": "/var/log/containers/gnocchi/gnocchi-metricd.log",
             "pattern": [
                 "ObjectNotFound: error opening pool 'metrics'"
@@ -3016,6 +3011,11 @@
         {
             "glob": "/usr/lib*/ImageMagick-6.5.4/config/policy.xml",
             "symbolic_name": "imagemagick_policy",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/logrotate.d/*",
+            "symbolic_name": "logrotate_conf",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -2537,7 +2537,12 @@
             "symbolic_name": "sysconfig_memcached"
         },
         {
-            "file": "/etc/sysconfig/()*mongod",
+            "file": "/etc/sysconfig/mongod",
+            "pattern": [],
+            "symbolic_name": "sysconfig_mongod"
+        },
+        {
+            "file": "/etc/opt/rh/rh-mongodb26/sysconfig/mongod",
             "pattern": [],
             "symbolic_name": "sysconfig_mongod"
         },
@@ -2550,11 +2555,6 @@
             "file": "/etc/sysconfig/network",
             "pattern": [],
             "symbolic_name": "sysconfig_network"
-        },
-        {
-            "file": "/etc/opt/rh/rh-mongodb26/sysconfig/()*mongod",
-            "pattern": [],
-            "symbolic_name": "sysconfig_rh_mongodb26"
         },
         {
             "file": "/etc/sysconfig/prelink",

--- a/uploader.json
+++ b/uploader.json
@@ -1244,11 +1244,6 @@
             "symbolic_name": "avc_cache_threshold"
         },
         {
-            "file": "/proc/driver/cciss/()*cciss.*",
-            "pattern": [],
-            "symbolic_name": "cciss"
-        },
-        {
             "file": "/sys/bus/usb/drivers/cdc_wdm/module/refcnt",
             "pattern": [],
             "symbolic_name": "cdc_wdm"
@@ -3154,6 +3149,11 @@
         {
             "glob": "/tomcat-logs/tomcat*/catalina.out",
             "symbolic_name": "catalina_out",
+            "pattern": []
+        },
+        {
+            "glob": "/proc/driver/cciss/cciss*",
+            "symbolic_name": "cciss",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -2728,11 +2728,6 @@
             "symbolic_name": "yum_conf"
         },
         {
-            "file": "/etc/yum.repos.d/()*.*\\.repo",
-            "pattern": [],
-            "symbolic_name": "yum_repos_d"
-        },
-        {
             "file": "/var/log/redhat-access-insights/redhat-access-insights.log",
             "pattern": [],
             "symbolic_name": "redhat_access_insights_log"
@@ -3142,6 +3137,11 @@
             "glob": "/etc/xinetd.d/*",
             "symbolic_name": "xinetd_conf",
             "pattern": []
+        },
+        {
+            "glob": "/etc/yum.repos.d/*",
+            "pattern": [],
+            "symbolic_name": "yum_repos_d"
         },
         {
             "glob": "/etc/httpd/conf.d/*/*.conf",

--- a/uploader.json
+++ b/uploader.json
@@ -1893,14 +1893,9 @@
             "symbolic_name": "messages"
         },
         {
-            "file": "/etc/()*modprobe\\.conf",
+            "file": "/etc/modprobe.conf",
             "pattern": [],
-            "symbolic_name": "modprobe_conf"
-        },
-        {
-            "file": "/etc/modprobe.d/()*.*\\.conf",
-            "pattern": [],
-            "symbolic_name": "modprobe_d"
+            "symbolic_name": "modprobe"
         },
         {
             "file": "/etc/()*mongod.conf",
@@ -3216,6 +3211,11 @@
         {
             "glob": "/sys/bus/pci/devices/*/mlx4_port[0-9]",
             "symbolic_name": "mlx4_port",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/modprobe.d/*.conf",
+            "symbolic_name": "modprobe",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -1663,11 +1663,6 @@
             "symbolic_name": "jbcs_httpd24_httpd_error_log"
         },
         {
-            "file": "/etc/sysconfig/network-scripts/()*ifcfg-.*",
-            "pattern": [],
-            "symbolic_name": "ifcfg"
-        },
-        {
             "file": "/etc/sysconfig/network-scripts/()*route-.*",
             "pattern": [],
             "symbolic_name": "ifcfg_static_route"
@@ -3164,6 +3159,11 @@
         {
             "glob": "/etc/systemd/journald.conf.d/*.conf",
             "symbolic_name": "etc_journald_conf_d",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/sysconfig/network-scripts/ifcfg-*",
+            "symbolic_name": "ifcfg",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -2624,11 +2624,6 @@
             "symbolic_name": "up2date_log"
         },
         {
-            "file": "/usr/lib/systemd/journald.conf.d/()*.+\\.conf",
-            "pattern": [],
-            "symbolic_name": "usr_journald_conf_d"
-        },
-        {
             "file": "/etc/vdsm/vdsm.conf",
             "pattern": [],
             "symbolic_name": "vdsm_conf"
@@ -3152,6 +3147,11 @@
         {
             "glob": "/run/tmpfiles.d/*.conf",
             "symbolic_name": "tmpfilesd",
+            "pattern": []
+        },
+        {
+            "glob": "/usr/lib/systemd/journald.conf.d/*.conf",
+            "symbolic_name": "usr_journald_conf_d",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -1969,51 +1969,6 @@
             "symbolic_name": "nfs_exports"
         },
         {
-            "file": "/etc/nginx/()*.conf",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
-            "file": "/etc/nginx/conf.d/()*",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
-            "file": "/etc/nginx/default.d/()*",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
-            "file": "/etc/opt/rh/rh-nginx()*/nginx/()*.conf",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
-            "file": "/etc/opt/rh/rh-nginx()*/nginx/conf.d/()*",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
-            "file": "/etc/opt/rh/rh-nginx()*/nginx/default.d/()*",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
-            "file": "/opt/rh/nginx()*/root/etc/nginx/()*.conf",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
-            "file": "/opt/rh/nginx()*/root/etc/nginx/conf.d/()*",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
-            "file": "/opt/rh/nginx()*/root/etc/nginx/default.d/()*",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
             "file": "/var/log/nova/nova-api.log",
             "pattern": [
                 "DEBUG oslo.messaging._drivers.impl_rabbit",
@@ -3144,6 +3099,51 @@
         {
             "glob": "/etc/exports.d/*.exports",
             "symbolic_name": "nfs_exports_d",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/nginx/*.conf",
+            "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/nginx/conf.d/*",
+            "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/nginx/default.d/*",
+            "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/opt/rh/nginx*/root/etc/nginx/*.conf",
+            "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/opt/rh/nginx*/root/etc/nginx/conf.d/*",
+            "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/opt/rh/nginx*/root/etc/nginx/default.d/*",
+            "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/opt/rh/rh-nginx*/nginx/*.conf",
+            "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/opt/rh/rh-nginx*/nginx/conf.d/*",
+            "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/opt/rh/rh-nginx*/nginx/default.d/*",
+            "symbolic_name": "nginx_conf",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -1316,13 +1316,6 @@
             "symbolic_name": "ceph_log"
         },
         {
-            "file": "/var/log/ceph/()*ceph-osd.*\\.log$",
-            "pattern": [
-                "common/Thread.cc"
-            ],
-            "symbolic_name": "ceph_osd_log"
-        },
-        {
             "file": "/proc/cgroups",
             "pattern": [],
             "symbolic_name": "cgroups"
@@ -3154,6 +3147,11 @@
         {
             "glob": "/proc/driver/cciss/cciss*",
             "symbolic_name": "cciss",
+            "pattern": []
+        },
+        {
+            "glob": "/var/log/ceph/ceph-osd*.log",
+            "symbolic_name": "ceph_osd_log",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -2718,12 +2718,7 @@
             "symbolic_name": "x86_pti_enabled"
         },
         {
-            "file": "/etc/()*xinetd\\.conf",
-            "pattern": [],
-            "symbolic_name": "xinetd_conf"
-        },
-        {
-            "file": "/etc/xinetd.d/()*.*",
+            "file": "/etc/xinetd.conf",
             "pattern": [],
             "symbolic_name": "xinetd_conf"
         },
@@ -3141,6 +3136,11 @@
         {
             "glob": "/etc/virt-who.d/*.conf",
             "symbolic_name": "virt_who_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/xinetd.d/*",
+            "symbolic_name": "xinetd_conf",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -1736,14 +1736,9 @@
             "symbolic_name": "ksmstate"
         },
         {
-            "file": "/etc/security/()*limits\\.conf",
+            "file": "/etc/security/limits.conf",
             "pattern": [],
             "symbolic_name": "limits_conf"
-        },
-        {
-            "file": "/etc/security/limits.d/()*.*\\.conf",
-            "pattern": [],
-            "symbolic_name": "limits_d"
         },
         {
             "file": "/etc/lvm/lvm.conf",
@@ -3211,6 +3206,11 @@
         {
             "glob": "/sys/fs/cgroup/cpu/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod[a-f0-9_]*.slice/cpu.cfs_quota_us",
             "symbolic_name": "kubepods_cpu_quota",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/security/limits.d/*.conf",
+            "symbolic_name": "limits_conf",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -1470,14 +1470,6 @@
             "symbolic_name": "x86_retp_enabled"
         },
         {
-            "file": "/var/log/dirsrv/.*/()*(errors|errors\\.2.*)",
-            "pattern": [
-                "DSRetroclPlugin - delete_changerecord: could not delete change record",
-                "We recommend to increase the entry cache size nsslapd-cachememsize"
-            ],
-            "symbolic_name": "dirsrv_errors"
-        },
-        {
             "file": "/var/log/dmesg",
             "pattern": [
                 "L1TF",
@@ -3167,6 +3159,11 @@
         {
             "glob": "/sys/devices/system/cpu/vulnerabilities/*",
             "symbolic_name": "cpu_vulns",
+            "pattern": []
+        },
+        {
+            "glob": "/var/log/dirsrv/*/errors*",
+            "symbolic_name": "dirsrv_errors",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -2607,21 +2607,6 @@
             "symbolic_name": "thp_use_zero_page"
         },
         {
-            "file": "/etc/tmpfiles.d/()*.*\\.conf",
-            "pattern": [],
-            "symbolic_name": "tmpfilesd"
-        },
-        {
-            "file": "/usr/lib/tmpfiles.d/()*.*\\.conf",
-            "pattern": [],
-            "symbolic_name": "tmpfilesd"
-        },
-        {
-            "file": "/run/tmpfiles.d/()*.*\\.conf",
-            "pattern": [],
-            "symbolic_name": "tmpfilesd"
-        },
-        {
             "file": "/etc/tuned.conf",
             "pattern": [],
             "symbolic_name": "tuned_conf"
@@ -3152,6 +3137,21 @@
         {
             "glob": "/conf/rhn/sysconfig/rhn/rhn-entitlement-cert.xml*",
             "symbolic_name": "rhn_entitlement_cert_xml",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/tmpfiles.d/*.conf",
+            "symbolic_name": "tmpfilesd",
+            "pattern": []
+        },
+        {
+            "glob": "/usr/lib/tmpfiles.d/*.conf",
+            "symbolic_name": "tmpfilesd",
+            "pattern": []
+        },
+        {
+            "glob": "/run/tmpfiles.d/*.conf",
+            "symbolic_name": "tmpfilesd",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -2248,11 +2248,6 @@
             "symbolic_name": "resolv_conf"
         },
         {
-            "file": "/etc/sysconfig/rhn/()*rhn-entitlement-cert\\.xml.*",
-            "pattern": [],
-            "symbolic_name": "rhn_entitlement_cert_xml"
-        },
-        {
             "file": "/etc/rhn/rhn.conf",
             "pattern": [],
             "symbolic_name": "rhn_conf"
@@ -3147,6 +3142,16 @@
         {
             "glob": "/etc/libvirt/qemu/*.xml",
             "symbolic_name": "qemu_xml",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/sysconfig/rhn/rhn-entitlement-cert.xml*",
+            "symbolic_name": "rhn_entitlement_cert_xml",
+            "pattern": []
+        },
+        {
+            "glob": "/conf/rhn/sysconfig/rhn/rhn-entitlement-cert.xml*",
+            "symbolic_name": "rhn_entitlement_cert_xml",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -1663,11 +1663,6 @@
             "symbolic_name": "jbcs_httpd24_httpd_error_log"
         },
         {
-            "file": "/etc/sysconfig/network-scripts/()*route-.*",
-            "pattern": [],
-            "symbolic_name": "ifcfg_static_route"
-        },
-        {
             "file": "/etc/ImageMagick/()*policy\\.xml",
             "pattern": [
                 "</policymap>",
@@ -3164,6 +3159,11 @@
         {
             "glob": "/etc/sysconfig/network-scripts/ifcfg-*",
             "symbolic_name": "ifcfg",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/sysconfig/network-scripts/route-*",
+            "symbolic_name": "ifcfg_static_route",
             "pattern": []
         },
         {

--- a/uploader.json
+++ b/uploader.json
@@ -1542,11 +1542,6 @@
             "symbolic_name": "etc_journald_conf"
         },
         {
-            "file": "/etc/systemd/journald.conf.d/()*.+\\.conf",
-            "pattern": [],
-            "symbolic_name": "etc_journald_conf_d"
-        },
-        {
             "file": "/etc/fstab",
             "pattern": [],
             "symbolic_name": "fstab"
@@ -3164,6 +3159,11 @@
         {
             "glob": "/var/log/dirsrv/*/errors*",
             "symbolic_name": "dirsrv_errors",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/systemd/journald.conf.d/*.conf",
+            "symbolic_name": "etc_journald_conf_d",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1663,11 +1663,6 @@
             "symbolic_name": "jbcs_httpd24_httpd_error_log"
         },
         {
-            "file": "/etc/sysconfig/network-scripts/()*route-.*",
-            "pattern": [],
-            "symbolic_name": "ifcfg_static_route"
-        },
-        {
             "file": "/etc/ImageMagick/()*policy\\.xml",
             "pattern": [
                 "</policymap>",
@@ -3159,6 +3154,11 @@
         {
             "glob": "/etc/sysconfig/network-scripts/ifcfg-*",
             "symbolic_name": "ifcfg",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/sysconfig/network-scripts/route-*",
+            "symbolic_name": "ifcfg_static_route",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -2248,11 +2248,6 @@
             "symbolic_name": "resolv_conf"
         },
         {
-            "file": "/etc/sysconfig/rhn/()*rhn-entitlement-cert\\.xml.*",
-            "pattern": [],
-            "symbolic_name": "rhn_entitlement_cert_xml"
-        },
-        {
             "file": "/etc/rhn/rhn.conf",
             "pattern": [],
             "symbolic_name": "rhn_conf"
@@ -3142,6 +3137,16 @@
         {
             "glob": "/etc/libvirt/qemu/*.xml",
             "symbolic_name": "qemu_xml",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/sysconfig/rhn/rhn-entitlement-cert.xml*",
+            "symbolic_name": "rhn_entitlement_cert_xml",
+            "pattern": []
+        },
+        {
+            "glob": "/conf/rhn/sysconfig/rhn/rhn-entitlement-cert.xml*",
+            "symbolic_name": "rhn_entitlement_cert_xml",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1537,7 +1537,7 @@
             "symbolic_name": "ovirt_engine_ui_log"
         },
         {
-            "file": "/etc/systemd/()*journald\\.conf",
+            "file": "/etc/systemd/journald.conf",
             "pattern": [],
             "symbolic_name": "etc_journald_conf"
         },

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1244,11 +1244,6 @@
             "symbolic_name": "avc_cache_threshold"
         },
         {
-            "file": "/proc/driver/cciss/()*cciss.*",
-            "pattern": [],
-            "symbolic_name": "cciss"
-        },
-        {
             "file": "/sys/bus/usb/drivers/cdc_wdm/module/refcnt",
             "pattern": [],
             "symbolic_name": "cdc_wdm"
@@ -3149,6 +3144,11 @@
         {
             "glob": "/tomcat-logs/tomcat*/catalina.out",
             "symbolic_name": "catalina_out",
+            "pattern": []
+        },
+        {
+            "glob": "/proc/driver/cciss/cciss*",
+            "symbolic_name": "cciss",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -2211,11 +2211,6 @@
             "symbolic_name": "qemu_conf"
         },
         {
-            "file": "/etc/libvirt/qemu/()*.+\\.xml",
-            "pattern": [],
-            "symbolic_name": "qemu_xml"
-        },
-        {
             "file": "/etc/rabbitmq/rabbitmq-env.conf",
             "pattern": [],
             "symbolic_name": "rabbitmq_env"
@@ -3142,6 +3137,11 @@
         {
             "glob": "/etc/yum/pluginconf.d/*.conf",
             "symbolic_name": "pluginconf_d",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/libvirt/qemu/*.xml",
+            "symbolic_name": "qemu_xml",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -2655,23 +2655,7 @@
             "symbolic_name": "vdsm_logger_conf"
         },
         {
-            "file": "/etc/()*virt-who\\.conf",
-            "pattern": [
-                "[",
-                "configs",
-                "debug",
-                "env",
-                "interval",
-                "log_",
-                "oneshot",
-                "owner",
-                "server",
-                "type"
-            ],
-            "symbolic_name": "virt_who_conf"
-        },
-        {
-            "file": "/etc/virt-who.d/()*.*\\.conf",
+            "file": "/etc/virt-who.conf",
             "pattern": [
                 "[",
                 "configs",
@@ -3147,6 +3131,11 @@
         {
             "glob": "/usr/lib/systemd/journald.conf.d/*.conf",
             "symbolic_name": "usr_journald_conf_d",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/virt-who.d/*.conf",
+            "symbolic_name": "virt_who_conf",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1736,14 +1736,9 @@
             "symbolic_name": "ksmstate"
         },
         {
-            "file": "/etc/security/()*limits\\.conf",
+            "file": "/etc/security/limits.conf",
             "pattern": [],
             "symbolic_name": "limits_conf"
-        },
-        {
-            "file": "/etc/security/limits.d/()*.*\\.conf",
-            "pattern": [],
-            "symbolic_name": "limits_d"
         },
         {
             "file": "/etc/lvm/lvm.conf",
@@ -3206,6 +3201,11 @@
         {
             "glob": "/sys/fs/cgroup/cpu/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod[a-f0-9_]*.slice/cpu.cfs_quota_us",
             "symbolic_name": "kubepods_cpu_quota",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/security/limits.d/*.conf",
+            "symbolic_name": "limits_conf",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1893,14 +1893,9 @@
             "symbolic_name": "messages"
         },
         {
-            "file": "/etc/()*modprobe\\.conf",
+            "file": "/etc/modprobe.conf",
             "pattern": [],
-            "symbolic_name": "modprobe_conf"
-        },
-        {
-            "file": "/etc/modprobe.d/()*.*\\.conf",
-            "pattern": [],
-            "symbolic_name": "modprobe_d"
+            "symbolic_name": "modprobe"
         },
         {
             "file": "/etc/()*mongod.conf",
@@ -3206,6 +3201,11 @@
         {
             "glob": "/etc/security/limits.d/*.conf",
             "symbolic_name": "limits_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/modprobe.d/*.conf",
+            "symbolic_name": "modprobe",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -2733,11 +2733,6 @@
             "symbolic_name": "logrotate_conf"
         },
         {
-            "file": "/etc/logrotate.d/().*",
-            "pattern": [],
-            "symbolic_name": "logrotate_conf"
-        },
-        {
             "file": "/etc/rhsm/facts/virt_uuid.facts",
             "pattern": [],
             "symbolic_name": "virt_uuid_facts"
@@ -3011,6 +3006,11 @@
         {
             "glob": "/usr/lib*/ImageMagick-6.5.4/config/policy.xml",
             "symbolic_name": "imagemagick_policy",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/logrotate.d/*",
+            "symbolic_name": "logrotate_conf",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1244,38 +1244,6 @@
             "symbolic_name": "avc_cache_threshold"
         },
         {
-            "file": "/var/log/tomcat/()*catalina\\.out",
-            "pattern": [
-                "APPARENT DEADLOCK!",
-                "NoCobblerTokenException: We had an error trying to login."
-            ],
-            "symbolic_name": "catalina_out"
-        },
-        {
-            "file": "/var/log/tomcat6/()*catalina\\.out",
-            "pattern": [
-                "APPARENT DEADLOCK!",
-                "NoCobblerTokenException: We had an error trying to login."
-            ],
-            "symbolic_name": "catalina_out"
-        },
-        {
-            "file": "/tomcat-logs/tomcat/()*catalina\\.out",
-            "pattern": [
-                "APPARENT DEADLOCK!",
-                "NoCobblerTokenException: We had an error trying to login."
-            ],
-            "symbolic_name": "catalina_out"
-        },
-        {
-            "file": "/tomcat-logs/tomcat6/()*catalina\\.out",
-            "pattern": [
-                "APPARENT DEADLOCK!",
-                "NoCobblerTokenException: We had an error trying to login."
-            ],
-            "symbolic_name": "catalina_out"
-        },
-        {
             "file": "/proc/driver/cciss/()*cciss.*",
             "pattern": [],
             "symbolic_name": "cciss"
@@ -3171,6 +3139,16 @@
         {
             "glob": "/proc/net/bonding/bond*",
             "symbolic_name": "bond",
+            "pattern": []
+        },
+        {
+            "glob": "/var/log/tomcat*/catalina.out",
+            "symbolic_name": "catalina_out",
+            "pattern": []
+        },
+        {
+            "glob": "/tomcat-logs/tomcat*/catalina.out",
+            "symbolic_name": "catalina_out",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -2532,7 +2532,12 @@
             "symbolic_name": "sysconfig_memcached"
         },
         {
-            "file": "/etc/sysconfig/()*mongod",
+            "file": "/etc/sysconfig/mongod",
+            "pattern": [],
+            "symbolic_name": "sysconfig_mongod"
+        },
+        {
+            "file": "/etc/opt/rh/rh-mongodb26/sysconfig/mongod",
             "pattern": [],
             "symbolic_name": "sysconfig_mongod"
         },
@@ -2545,11 +2550,6 @@
             "file": "/etc/sysconfig/network",
             "pattern": [],
             "symbolic_name": "sysconfig_network"
-        },
-        {
-            "file": "/etc/opt/rh/rh-mongodb26/sysconfig/()*mongod",
-            "pattern": [],
-            "symbolic_name": "sysconfig_rh_mongodb26"
         },
         {
             "file": "/etc/sysconfig/prelink",

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1663,25 +1663,7 @@
             "symbolic_name": "jbcs_httpd24_httpd_error_log"
         },
         {
-            "file": "/etc/ImageMagick/()*policy\\.xml",
-            "pattern": [
-                "</policymap>",
-                "<policy",
-                "<policymap>"
-            ],
-            "symbolic_name": "imagemagick_policy"
-        },
-        {
-            "file": "/usr/lib64/ImageMagick-6.5.4/config/()*policy\\.xml",
-            "pattern": [
-                "</policymap>",
-                "<policy",
-                "<policymap>"
-            ],
-            "symbolic_name": "imagemagick_policy"
-        },
-        {
-            "file": "/usr/lib/ImageMagick-6.5.4/config/()*policy\\.xml",
+            "file": "/etc/ImageMagick/policy.xml",
             "pattern": [
                 "</policymap>",
                 "<policy",
@@ -3159,6 +3141,11 @@
         {
             "glob": "/etc/sysconfig/network-scripts/route-*",
             "symbolic_name": "ifcfg_static_route",
+            "pattern": []
+        },
+        {
+            "glob": "/usr/lib*/ImageMagick-6.5.4/config/policy.xml",
+            "symbolic_name": "imagemagick_policy",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -2713,12 +2713,7 @@
             "symbolic_name": "x86_pti_enabled"
         },
         {
-            "file": "/etc/()*xinetd\\.conf",
-            "pattern": [],
-            "symbolic_name": "xinetd_conf"
-        },
-        {
-            "file": "/etc/xinetd.d/()*.*",
+            "file": "/etc/xinetd.conf",
             "pattern": [],
             "symbolic_name": "xinetd_conf"
         },
@@ -3136,6 +3131,11 @@
         {
             "glob": "/etc/virt-who.d/*.conf",
             "symbolic_name": "virt_who_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/xinetd.d/*",
+            "symbolic_name": "xinetd_conf",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1898,13 +1898,23 @@
             "symbolic_name": "modprobe"
         },
         {
-            "file": "/etc/()*mongod.conf",
+            "file": "/etc/mongod.conf",
             "pattern": [
                 "dbpath",
                 "destination",
                 "syslog",
                 "systemLog"
             ],
+            "symbolic_name": "mongod_conf"
+        },
+        {
+            "file": "/etc/mongodb.conf",
+            "pattern": [],
+            "symbolic_name": "mongod_conf"
+        },
+        {
+            "file": "/etc/opt/rh/rh-mongodb26/mongod.conf",
+            "pattern": [],
             "symbolic_name": "mongod_conf"
         },
         {
@@ -2311,15 +2321,6 @@
             "file": "/etc/resolv.conf",
             "pattern": [],
             "symbolic_name": "resolv_conf"
-        },
-        {
-            "file": "/etc/opt/rh/rh-mongodb26/()*mongod.conf",
-            "pattern": [
-                "destination",
-                "syslog",
-                "systemLog"
-            ],
-            "symbolic_name": "rh_mongodb26_conf"
         },
         {
             "file": "/etc/sysconfig/rhn/()*rhn-entitlement-cert\\.xml.*",

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -2619,11 +2619,6 @@
             "symbolic_name": "up2date_log"
         },
         {
-            "file": "/usr/lib/systemd/journald.conf.d/()*.+\\.conf",
-            "pattern": [],
-            "symbolic_name": "usr_journald_conf_d"
-        },
-        {
             "file": "/etc/vdsm/vdsm.conf",
             "pattern": [],
             "symbolic_name": "vdsm_conf"
@@ -3147,6 +3142,11 @@
         {
             "glob": "/run/tmpfiles.d/*.conf",
             "symbolic_name": "tmpfilesd",
+            "pattern": []
+        },
+        {
+            "glob": "/usr/lib/systemd/journald.conf.d/*.conf",
+            "symbolic_name": "usr_journald_conf_d",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1969,14 +1969,6 @@
             "symbolic_name": "nfs_exports"
         },
         {
-            "file": "/etc/exports.d/()*.*\\.exports",
-            "pattern": [
-                "*",
-                "no_root_squash"
-            ],
-            "symbolic_name": "nfs_exports_d"
-        },
-        {
             "file": "/etc/nginx/()*.conf",
             "pattern": [],
             "symbolic_name": "nginx_conf"
@@ -3142,6 +3134,11 @@
         {
             "glob": "/sys/class/net/*/address",
             "symbolic_name": "mac_addresses",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/exports.d/*.exports",
+            "symbolic_name": "nfs_exports_d",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -2179,18 +2179,6 @@
             "symbolic_name": "postgresql_conf"
         },
         {
-            "file": "/var/lib/pgsql/data/pg_log/()*postgresql-.+\\.log",
-            "pattern": [
-                "FATAL",
-                "checkpoints are occurring too frequently",
-                "connection limit exceeded for non-superusers",
-                "database is not accepting commands to avoid wraparound data loss in database",
-                "must be vacuumed within",
-                "remaining connection slots are reserved for non-replication superuser connections"
-            ],
-            "symbolic_name": "postgresql_log"
-        },
-        {
             "file": "/proc/net/snmp",
             "pattern": [],
             "symbolic_name": "proc_snmp_ipv4"
@@ -3134,6 +3122,21 @@
         {
             "glob": "/etc/opt/rh/rh-nginx*/nginx/default.d/*",
             "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/var/lib/pgsql/data/pg_log/postgresql-*.log",
+            "symbolic_name": "postgresql_log",
+            "pattern": []
+        },
+        {
+            "glob": "/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_log/postgresql-*.log",
+            "symbolic_name": "postgresql_log",
+            "pattern": []
+        },
+        {
+            "glob": "/database/postgresql-*.log",
+            "symbolic_name": "postgresql_log",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1244,11 +1244,6 @@
             "symbolic_name": "avc_cache_threshold"
         },
         {
-            "file": "/proc/net/bonding/()*bond.*",
-            "pattern": [],
-            "symbolic_name": "bond"
-        },
-        {
             "file": "/var/log/tomcat/()*catalina\\.out",
             "pattern": [
                 "APPARENT DEADLOCK!",
@@ -3173,6 +3168,11 @@
         }
     ],
     "globs": [
+        {
+            "glob": "/proc/net/bonding/bond*",
+            "symbolic_name": "bond",
+            "pattern": []
+        },
         {
             "glob": "/sys/devices/system/cpu/cpu[0-9]*/online",
             "symbolic_name": "cpu_cores",

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1726,7 +1726,7 @@
             "symbolic_name": "kexec_crash_size"
         },
         {
-            "file": "/etc/()*krb5\\.conf",
+            "file": "/etc/krb5.conf",
             "pattern": [],
             "symbolic_name": "krb5"
         },
@@ -3200,7 +3200,7 @@
         },
         {
             "glob": "/etc/krb5.conf.d/*",
-            "symbolic_name": "krb5_conf_d",
+            "symbolic_name": "krb5",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1542,11 +1542,6 @@
             "symbolic_name": "etc_journald_conf"
         },
         {
-            "file": "/etc/systemd/journald.conf.d/()*.+\\.conf",
-            "pattern": [],
-            "symbolic_name": "etc_journald_conf_d"
-        },
-        {
             "file": "/etc/fstab",
             "pattern": [],
             "symbolic_name": "fstab"
@@ -3159,6 +3154,11 @@
         {
             "glob": "/var/log/dirsrv/*/errors*",
             "symbolic_name": "dirsrv_errors",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/systemd/journald.conf.d/*.conf",
+            "symbolic_name": "etc_journald_conf_d",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1969,51 +1969,6 @@
             "symbolic_name": "nfs_exports"
         },
         {
-            "file": "/etc/nginx/()*.conf",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
-            "file": "/etc/nginx/conf.d/()*",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
-            "file": "/etc/nginx/default.d/()*",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
-            "file": "/etc/opt/rh/rh-nginx()*/nginx/()*.conf",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
-            "file": "/etc/opt/rh/rh-nginx()*/nginx/conf.d/()*",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
-            "file": "/etc/opt/rh/rh-nginx()*/nginx/default.d/()*",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
-            "file": "/opt/rh/nginx()*/root/etc/nginx/()*.conf",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
-            "file": "/opt/rh/nginx()*/root/etc/nginx/conf.d/()*",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
-            "file": "/opt/rh/nginx()*/root/etc/nginx/default.d/()*",
-            "pattern": [],
-            "symbolic_name": "nginx_conf"
-        },
-        {
             "file": "/var/log/nova/nova-api.log",
             "pattern": [
                 "DEBUG oslo.messaging._drivers.impl_rabbit",
@@ -3139,6 +3094,51 @@
         {
             "glob": "/etc/exports.d/*.exports",
             "symbolic_name": "nfs_exports_d",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/nginx/*.conf",
+            "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/nginx/conf.d/*",
+            "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/nginx/default.d/*",
+            "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/opt/rh/nginx*/root/etc/nginx/*.conf",
+            "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/opt/rh/nginx*/root/etc/nginx/conf.d/*",
+            "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/opt/rh/nginx*/root/etc/nginx/default.d/*",
+            "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/opt/rh/rh-nginx*/nginx/*.conf",
+            "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/opt/rh/rh-nginx*/nginx/conf.d/*",
+            "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/opt/rh/rh-nginx*/nginx/default.d/*",
+            "symbolic_name": "nginx_conf",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -2174,11 +2174,6 @@
             "symbolic_name": "password_auth"
         },
         {
-            "file": "/etc/yum/pluginconf.d/()*\\w+\\.conf",
-            "pattern": [],
-            "symbolic_name": "pluginconf_d"
-        },
-        {
             "file": "/var/lib/pgsql/data/postgresql.conf",
             "pattern": [],
             "symbolic_name": "postgresql_conf"
@@ -3139,6 +3134,11 @@
         {
             "glob": "/etc/opt/rh/rh-nginx*/nginx/default.d/*",
             "symbolic_name": "nginx_conf",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/yum/pluginconf.d/*.conf",
+            "symbolic_name": "pluginconf_d",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1316,13 +1316,6 @@
             "symbolic_name": "ceph_log"
         },
         {
-            "file": "/var/log/ceph/()*ceph-osd.*\\.log$",
-            "pattern": [
-                "common/Thread.cc"
-            ],
-            "symbolic_name": "ceph_osd_log"
-        },
-        {
             "file": "/proc/cgroups",
             "pattern": [],
             "symbolic_name": "cgroups"
@@ -3149,6 +3142,11 @@
         {
             "glob": "/proc/driver/cciss/cciss*",
             "symbolic_name": "cciss",
+            "pattern": []
+        },
+        {
+            "glob": "/var/log/ceph/ceph-osd*.log",
+            "symbolic_name": "ceph_osd_log",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1470,14 +1470,6 @@
             "symbolic_name": "x86_retp_enabled"
         },
         {
-            "file": "/var/log/dirsrv/.*/()*(errors|errors\\.2.*)",
-            "pattern": [
-                "DSRetroclPlugin - delete_changerecord: could not delete change record",
-                "We recommend to increase the entry cache size nsslapd-cachememsize"
-            ],
-            "symbolic_name": "dirsrv_errors"
-        },
-        {
             "file": "/var/log/dmesg",
             "pattern": [
                 "L1TF",
@@ -3162,6 +3154,11 @@
         {
             "glob": "/sys/devices/system/cpu/vulnerabilities/*",
             "symbolic_name": "cpu_vulns",
+            "pattern": []
+        },
+        {
+            "glob": "/var/log/dirsrv/*/errors*",
+            "symbolic_name": "dirsrv_errors",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -1663,11 +1663,6 @@
             "symbolic_name": "jbcs_httpd24_httpd_error_log"
         },
         {
-            "file": "/etc/sysconfig/network-scripts/()*ifcfg-.*",
-            "pattern": [],
-            "symbolic_name": "ifcfg"
-        },
-        {
             "file": "/etc/sysconfig/network-scripts/()*route-.*",
             "pattern": [],
             "symbolic_name": "ifcfg_static_route"
@@ -3159,6 +3154,11 @@
         {
             "glob": "/etc/systemd/journald.conf.d/*.conf",
             "symbolic_name": "etc_journald_conf_d",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/sysconfig/network-scripts/ifcfg-*",
+            "symbolic_name": "ifcfg",
             "pattern": []
         },
         {

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -2723,11 +2723,6 @@
             "symbolic_name": "yum_conf"
         },
         {
-            "file": "/etc/yum.repos.d/()*.*\\.repo",
-            "pattern": [],
-            "symbolic_name": "yum_repos_d"
-        },
-        {
             "file": "/var/log/redhat_access_proactive/redhat_access_proactive.log",
             "pattern": [],
             "symbolic_name": "redhat_access_proactive_log"
@@ -3137,6 +3132,11 @@
             "glob": "/etc/xinetd.d/*",
             "symbolic_name": "xinetd_conf",
             "pattern": []
+        },
+        {
+            "glob": "/etc/yum.repos.d/*",
+            "pattern": [],
+            "symbolic_name": "yum_repos_d"
         },
         {
             "glob": "/etc/httpd/conf.d/*/*.conf",

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -2602,21 +2602,6 @@
             "symbolic_name": "thp_use_zero_page"
         },
         {
-            "file": "/etc/tmpfiles.d/()*.*\\.conf",
-            "pattern": [],
-            "symbolic_name": "tmpfilesd"
-        },
-        {
-            "file": "/usr/lib/tmpfiles.d/()*.*\\.conf",
-            "pattern": [],
-            "symbolic_name": "tmpfilesd"
-        },
-        {
-            "file": "/run/tmpfiles.d/()*.*\\.conf",
-            "pattern": [],
-            "symbolic_name": "tmpfilesd"
-        },
-        {
             "file": "/etc/tuned.conf",
             "pattern": [],
             "symbolic_name": "tuned_conf"
@@ -3147,6 +3132,21 @@
         {
             "glob": "/conf/rhn/sysconfig/rhn/rhn-entitlement-cert.xml*",
             "symbolic_name": "rhn_entitlement_cert_xml",
+            "pattern": []
+        },
+        {
+            "glob": "/etc/tmpfiles.d/*.conf",
+            "symbolic_name": "tmpfilesd",
+            "pattern": []
+        },
+        {
+            "glob": "/usr/lib/tmpfiles.d/*.conf",
+            "symbolic_name": "tmpfilesd",
+            "pattern": []
+        },
+        {
+            "glob": "/run/tmpfiles.d/*.conf",
+            "symbolic_name": "tmpfilesd",
             "pattern": []
         },
         {


### PR DESCRIPTION
* Convert all regex file specs using `()` hack to actual glob specs
* Make specs consistent with insights core spec
* Convert one spec in each commit
* Convert bond spec