### PR TITLE
Add v1 to static assets path for CRC

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
                             ssh-add \"$privateKeyFile\"
                             cp $AKAMAI_HOST_KEY ~/.ssh/known_hosts
                             chmod 600 ~/.ssh/known_hosts
-                            rsync -arv -e \"ssh -2\" ./uploader* sshacs@cloud-unprotected.upload.akamai.com:/822386/api/static/
+                            rsync -arv -e \"ssh -2\" ./uploader* sshacs@cloud-unprotected.upload.akamai.com:/822386/api/v1/static/
                             """
                   }
              }
@@ -62,8 +62,8 @@ pipeline {
                             ssh-add \"$privateKeyFile\"
                             cp $AKAMAI_HOST_KEY ~/.ssh/known_hosts
                             chmod 600 ~/.ssh/known_hosts
-                            rsync -arv -e \"ssh -2\" ./insights-core.egg* sshacs@cloud-unprotected.upload.akamai.com:/822386/api/static/
-                            rsync -arv -e \"ssh -2\" ./changelog.txt sshacs@cloud-unprotected.upload.akamai.com:/822386/api/static/
+                            rsync -arv -e \"ssh -2\" ./insights-core.egg* sshacs@cloud-unprotected.upload.akamai.com:/822386/api/v1/static/
+                            rsync -arv -e \"ssh -2\" ./changelog.txt sshacs@cloud-unprotected.upload.akamai.com:/822386/api/v1/static/
                             """
                   }
              }


### PR DESCRIPTION
It sounds like the new consensus is that `/v1` should be a part of the path for the static assets. I've already updated all the rules required; it just needs to deploy to the right place in Prod now.