### PR TITLE
Added specs for proc/net/netstat

### DIFF
--- a/uploader.json
+++ b/uploader.json
@@ -2517,6 +2517,11 @@
             "symbolic_name": "postgresql_log"
         },
         {
+            "file": "/proc/net/netstat",
+            "pattern": [],
+            "symbolic_name": "proc_netstat"
+        },
+        {
             "file": "/proc/net/snmp",
             "pattern": [],
             "symbolic_name": "proc_snmp_ipv4"

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -2450,6 +2450,11 @@
             "symbolic_name": "postgresql_log"
         },
         {
+            "file": "/proc/net/netstat",
+            "pattern": [],
+            "symbolic_name": "proc_netstat"
+        },
+        {
             "file": "/proc/net/snmp",
             "pattern": [],
             "symbolic_name": "proc_snmp_ipv4"


### PR DESCRIPTION
Added specs for `/proc/net/netstat`, the stats are absent in the other specs which are already covered.