### PR TITLE
Only send successful deployment when it actually deploying

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,6 +45,9 @@ pipeline {
                             """
                   }
              }
+             slackSend channel: '#team-platform-data',
+                       color: 'good',
+                       message: 'Uploader.json and Egg successfully Deployed'
         }
       }
       stage('Deploy Egg') {
@@ -70,19 +73,17 @@ pipeline {
                             """
                   }
              }
+              slackSend channel: '#team-platform-data',
+                        color: 'good',
+                        message: 'Uploader.json and Egg successfully Deployed'
         }
       }
   }
   post {
-    success {
-      slackSend channel: '#team-platform-data',
-                color: 'good',
-                message: 'Uploader.json and Egg successfully Deployed'
-    }
     failure {
       slackSend channel: '#team-platform-data',
                 color: 'bad',
-                message: 'Something went wrong with uploader.json and egg deployment'
+                message: 'Something may have gone wrong with uploader.json and egg deployment'
     }
   }
 }


### PR DESCRIPTION
We keep getting these with every PR and that's no good.
This will ensure we only get these when the deployment happens

Signed-off-by: Stephen Adams <tsadams@gmail.com>