### PR TITLE
updated grubby specs

### DIFF
--- a/uploader.json
+++ b/uploader.json
@@ -341,7 +341,7 @@
             "symbolic_name": "grubby_default_index"
         },
         {
-            "command": "/usr/sbin/grubby --default-kernel",
+            "command": "/sbin/grubby --default-kernel",
             "pattern": [],
             "symbolic_name": "grubby_default_kernel"
         },

--- a/uploader.json
+++ b/uploader.json
@@ -346,6 +346,11 @@
             "symbolic_name": "grubby_default_kernel"
         },
         {
+            "command": "/usr/sbin/grubby --default-kernel",
+            "pattern": [],
+            "symbolic_name": "grubby_default_kernel"
+        },
+        {
             "command": "/usr/bin/crontab -l -u heat",
             "pattern": [
                 "heat-manage"

--- a/uploader.json
+++ b/uploader.json
@@ -346,11 +346,6 @@
             "symbolic_name": "grubby_default_kernel"
         },
         {
-            "command": "/usr/sbin/grubby --default-kernel",
-            "pattern": [],
-            "symbolic_name": "grubby_default_kernel"
-        },
-        {
             "command": "/usr/bin/crontab -l -u heat",
             "pattern": [
                 "heat-manage"

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -341,7 +341,7 @@
             "symbolic_name": "grubby_default_index"
         },
         {
-            "command": "/usr/sbin/grubby --default-kernel",
+            "command": "/sbin/grubby --default-kernel",
             "pattern": [],
             "symbolic_name": "grubby_default_kernel"
         },

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -346,6 +346,11 @@
             "symbolic_name": "grubby_default_kernel"
         },
         {
+            "command": "/usr/sbin/grubby --default-kernel",
+            "pattern": [],
+            "symbolic_name": "grubby_default_kernel"
+        },
+        {
             "command": "/usr/bin/crontab -l -u heat",
             "pattern": [
                 "heat-manage"

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -346,11 +346,6 @@
             "symbolic_name": "grubby_default_kernel"
         },
         {
-            "command": "/usr/sbin/grubby --default-kernel",
-            "pattern": [],
-            "symbolic_name": "grubby_default_kernel"
-        },
-        {
             "command": "/usr/bin/crontab -l -u heat",
             "pattern": [
                 "heat-manage"


### PR DESCRIPTION
On RHEL6 spec is in different path,

https://github.com/RedHatInsights/insights-core/issues/2578
https://github.com/RedHatInsights/insights-core/pull/2579
