### PR TITLE
uploader.json: add /etc/ipa to certificates_enddate

### DIFF
--- a/uploader.json
+++ b/uploader.json
@@ -81,7 +81,7 @@
             "symbolic_name": "ceph_insights"
         },
         {
-            "command": "/usr/bin/find /etc/origin/node /etc/origin/master /etc/pki -type f -exec /usr/bin/openssl x509 -noout -enddate -in '{}' \\; -exec echo 'FileName= {}' \\;",
+            "command": "/usr/bin/find /etc/origin/node /etc/origin/master /etc/pki /etc/ipa -type f -exec /usr/bin/openssl x509 -noout -enddate -in '{}' \\; -exec echo 'FileName= {}' \\;",
             "pattern": [],
             "symbolic_name": "certificates_enddate"
         },

--- a/uploader.v2.json
+++ b/uploader.v2.json
@@ -76,7 +76,7 @@
             "symbolic_name": "ceph_insights"
         },
         {
-            "command": "/usr/bin/find /etc/origin/node /etc/origin/master /etc/pki -type f -exec /usr/bin/openssl x509 -noout -enddate -in '{}' \\; -exec echo 'FileName= {}' \\;",
+            "command": "/usr/bin/find /etc/origin/node /etc/origin/master /etc/pki /etc/ipa -type f -exec /usr/bin/openssl x509 -noout -enddate -in '{}' \\; -exec echo 'FileName= {}' \\;",
             "pattern": [],
             "symbolic_name": "certificates_enddate"
         },


### PR DESCRIPTION
The FreeIPA CA certificate at /etc/ipa/ca.crt expiration date should
be monitored too.

Signed-off-by: François Cami <fcami@redhat.com>